### PR TITLE
Fix crc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,19 @@
 [package]
 name = "ab_versions"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Carl J. Geib"]
-edition = "2021"
+edition = "2024"
 
 
 [dependencies]
-cfb = "0.8"
-thiserror = "1.0.20"
-rayon = "1.7"
+cfb = "0.11"
+thiserror = "2.0.16"
+rayon = "1.11"
 crc32fast = "1.5.0"
 
 
-
 [dev-dependencies]
-sevenz-rust = "0.5"
-tempfile = "3.1.0"
+sevenz-rust = "0.6"
+tempfile = "3.21.0"
 walkdir = "2"
 nom = "7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 cfb = "0.8"
 thiserror = "1.0.20"
 rayon = "1.7"
+crc32fast = "1.5.0"
 
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,14 @@
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 
+use cfb::CompoundFile;
+use crc32fast::Hasher;
+use rayon::prelude::*;
+use std::fs::File;
 use std::io::{Read, Write};
+use std::os::unix::fs::FileExt;
 use std::path::Path;
 use std::{fmt, fmt::Display};
-use rayon::prelude::*;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -19,6 +23,8 @@ pub enum FTypeError {
     NoVersion,
     #[error("Version information appears to be invalid")]
     InvalidVersion,
+    #[error("No Password protection file was found")]
+    NoProtFile,
 }
 
 #[derive(Error, Debug)]
@@ -28,6 +34,11 @@ pub enum FtvFileError {
 
     #[error("The file does not appear to be a valid FactoryTalk View ME File: {0:?}")]
     FileTypeError(#[from] FTypeError),
+}
+
+pub enum MeFiletype {
+    Apa,
+    Mer,
 }
 
 /// Holds the version number of the file.
@@ -46,16 +57,16 @@ impl Display for FileVersion {
 }
 
 impl FileVersion {
+    #[must_use]
     pub fn is_old(&self) -> bool {
         self.major_rev < 5
     }
 
+    #[must_use]
     pub fn is_restorable(&self) -> bool {
         self.major_rev >= 4
     }
 }
-
-
 
 // https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc
 /// Returns a `FactoryTalk` View File Version for the file passed into it.
@@ -123,13 +134,15 @@ pub fn get_version<P: AsRef<Path>>(filename: &P) -> Result<FileVersion, FtvFileE
 //this parrallel version is mainly for the python bindings to take advantage
 //or the parrallelization
 pub fn get_versions<P>(files: &[P]) -> Vec<Result<FileVersion, FtvFileError>>
-    where P: AsRef<Path> + Sync
+where
+    P: AsRef<Path> + Sync,
 {
-    files.as_parallel_slice().par_iter().map(|file| -> Result<FileVersion, FtvFileError> {
-        get_version(file)
-    }).collect()
+    files
+        .as_parallel_slice()
+        .par_iter()
+        .map(|file| -> Result<FileVersion, FtvFileError> { get_version(file) })
+        .collect()
 }
-
 
 // https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc
 /// Returns true/false if a `FactoryTalk` View file (APA or MER) is protected.
@@ -153,23 +166,33 @@ pub fn get_versions<P>(files: &[P]) -> Vec<Result<FileVersion, FtvFileError>>
 pub fn is_protected<P: AsRef<Path>>(path: &P) -> Result<bool, FtvFileError> {
     let mut file = cfb::open(path)?;
 
-    let mut prot_stream = file.open_stream("/FILE_PROTECTION")?;
+    if let Ok(mut prot_stream) = file.open_stream("/FILE_PROTECTION") {
+        // I'm not quite sure exactly what the contents of the file is if it is unprotected
+        // So far has always been 7 bytes, and the the second byte has always been a 3,
+        // and the rest have been 0. If it's password protected it's always been greater than
+        // 7 bytes. I assume it's some hashed form of the password.
+        // The exception here is if when an MER is exported with the "Never Convert" option selected
+        // the bytes pattern seems to always be: [00, 03, 00, 01, 00, 00, 00], pretty similar to the
+        // unlocked bytes, but with the 4th byte set to 1.
 
-    // I'm not quite sure exactly what the contents of the file is if it is unprotected
-    // So far has always been 7 bytes, and the the second byte has always been a 3,
-    // and the rest have been 0. If it's password protected it's always been greater than
-    // 7 bytes. I assume it's some hashed form of the password.
-    // The exception here is if when an MER is exported with the "Never Convert" option selected
-    // the bytes pattern seems to always be: [00, 03, 00, 01, 00, 00, 00], pretty similar to the
-    // unlocked bytes, but with the 4th byte set to 1.
-
-    Ok(if prot_stream.len() == 7 {
-        let mut buf: Vec<u8> = Vec::with_capacity(7);
-        prot_stream.read_to_end(&mut buf)?;
-        buf == [0x00, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00]
+        Ok(if prot_stream.len() == 7 {
+            let mut buf: Vec<u8> = Vec::with_capacity(7);
+            prot_stream.read_to_end(&mut buf)?;
+            buf == [0x00, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00]
+        } else {
+            prot_stream.len() > 7
+        })
+    } else if let Ok(mut prot_stream) = file.open_stream("/FTSPHasPwd") {
+        Ok(if prot_stream.len() >= 4 {
+            let mut buf: Vec<u8> = Vec::with_capacity(prot_stream.len() as usize);
+            prot_stream.read_to_end(&mut buf)?;
+            buf[0] != 0x00
+        } else {
+            false
+        })
     } else {
-        prot_stream.len() > 7
-    })
+        Err(FTypeError::NoProtFile.into())
+    }
 }
 
 // https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc
@@ -194,11 +217,14 @@ pub fn is_protected<P: AsRef<Path>>(path: &P) -> Result<bool, FtvFileError> {
 //this parrallel version is mainly for the python bindings to take advantage
 //or the parrallelization
 pub fn are_protected<P>(files: &[P]) -> Vec<Result<bool, FtvFileError>>
-    where P: AsRef<Path> + Sync
+where
+    P: AsRef<Path> + Sync,
 {
-    files.as_parallel_slice().par_iter().map(|file| -> Result<bool, FtvFileError> {
-        is_protected(file)
-    }).collect()
+    files
+        .as_parallel_slice()
+        .par_iter()
+        .map(|file| -> Result<bool, FtvFileError> { is_protected(file) })
+        .collect()
 }
 
 // https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc
@@ -240,7 +266,6 @@ pub fn strip_protection<P: AsRef<Path>>(path: P) -> Result<(), FtvFileError> {
     //then I need to modify the VERSION_INFORMATION to look like a newer version (I'll use v5.10)
     //no clue if this actually works on anything < v4 since I have nothing to test against
 
-
     let mut file = cfb::open_rw(&path)?;
 
     let version = get_version(&path)?;
@@ -255,13 +280,16 @@ pub fn strip_protection<P: AsRef<Path>>(path: P) -> Result<(), FtvFileError> {
 
         let mut ver_stream = file.open_stream("/VERSION_INFORMATION")?;
         ver_stream.write_all(&[0x03, 0x05, 0x0A])?;
-
     } else {
         //if version >= 5 use normal method just stip protection
         let mut stream = file.open_stream("/FILE_PROTECTION")?;
         stream.set_len(7)?;
         stream.write_all(&[0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00])?;
     }
+
+    drop(file);
+
+    fix_crc(&path)?;
 
     Ok(())
 }
@@ -288,7 +316,8 @@ pub fn strip_protection<P: AsRef<Path>>(path: P) -> Result<(), FtvFileError> {
 //this parrallel version is mainly for the python bindings to take advantage
 //or the parrallelization
 pub fn strip_protections<P>(files: &[P]) -> Result<(), FtvFileError>
-    where P: AsRef<Path> + Sync
+where
+    P: AsRef<Path> + Sync,
 {
     // Note from what I recall of my earlier testing, removing the stream "/FILE_PROTECTION"
     // or setting it to a single byte of 0, or 7 bytes of 0, also removed the protection and
@@ -301,9 +330,47 @@ pub fn strip_protections<P>(files: &[P]) -> Result<(), FtvFileError>
     // MER Version 5 which doesn't give you a choice and is always "Never Convert", and it always seems
     // to work
 
-    files.as_parallel_slice().par_iter().map(|file| -> Result<(), FtvFileError> {
-        strip_protection(file)
-    }).collect()
+    files
+        .as_parallel_slice()
+        .par_iter()
+        .map(|file| -> Result<(), FtvFileError> { strip_protection(file) })
+        .collect()
+}
+
+/// Updates the CRC32 at the end of a `FactoryTalk` View
+/// MER or APA file, to ensure it restores properly after stripping the protection
+///
+/// # Arguments
+///
+/// * `path` - A path to the file to be checked
+///
+/// # Examples
+///
+/// ```
+/// use ab_versions::fix_crc;
+/// fix_crc(&path_to_file).unwrap();
+/// ```
+///
+/// # Errors
+///
+/// Will return `Err`  if there is an error trying to access the file,
+// or the file is invalid.
+pub fn fix_crc<P: AsRef<Path>>(path: P) -> Result<(), FtvFileError> {
+    let mut file = File::options().read(true).write(true).open(path)?;
+    let mut buffer = Vec::new();
+    file.read_to_end(&mut buffer)?;
+
+    let mut hasher = Hasher::new();
+    hasher.update(&buffer[..buffer.len() - 4]);
+    let checksum = hasher.finalize();
+
+    file.write_at(&checksum.to_le_bytes(), buffer.len() as u64 - 4)?;
+    file.flush()?;
+    Ok(())
+}
+
+pub fn file_type(file: &CompoundFile<File>) -> MeFiletype {
+    todo!()
 }
 
 #[cfg(test)]
@@ -349,9 +416,9 @@ mod tests {
 
     fn process_archive<P: AsRef<std::path::Path>>(archive_path: P, state: &FileState) {
         use super::*;
+        use sevenz_rust::decompress_file;
         use tempfile::tempdir;
         use walkdir::WalkDir;
-        use sevenz_rust::decompress_file;
 
         let extract_dir = tempdir().expect(
             "Test failed due to inability to create a temporary directory to uncompress the files",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 #![deny(clippy::pedantic)]
 
 use crc32fast::Hasher;
-use log::error;
 use rayon::prelude::*;
 use std::{
     fmt,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,17 @@
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 
-use cfb::CompoundFile;
 use crc32fast::Hasher;
+use log::error;
 use rayon::prelude::*;
-use std::fs::File;
-use std::io::{Read, Write};
-use std::os::unix::fs::FileExt;
-use std::path::Path;
-use std::{fmt, fmt::Display};
+use std::{
+    fmt,
+    fmt::Display,
+    fs::File,
+    io::{Read, Write},
+    os::unix::fs::FileExt,
+    path::Path,
+};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -25,6 +28,8 @@ pub enum FTypeError {
     InvalidVersion,
     #[error("No Password protection file was found")]
     NoProtFile,
+    #[error("The Password protection file appears to be invalid")]
+    ProtFileInvalid,
 }
 
 #[derive(Error, Debug)]
@@ -99,7 +104,7 @@ pub fn get_version<P: AsRef<Path>>(filename: &P) -> Result<FileVersion, FtvFileE
                         _ => err.into(),
                     }
                 })?;
-        let mut buffer = Vec::new();
+        let mut buffer = Vec::with_capacity(stream.len() as usize);
         stream.read_to_end(&mut buffer)?;
         buffer
     };
@@ -185,8 +190,8 @@ pub fn is_protected<P: AsRef<Path>>(path: &P) -> Result<bool, FtvFileError> {
         })
     } else if let Ok(mut prot_stream) = file.open_stream("/FTSPHasPwd") {
         Ok(if prot_stream.len() >= 4 {
-            let mut buf: Vec<u8> = Vec::with_capacity(prot_stream.len() as usize);
-            prot_stream.read_to_end(&mut buf)?;
+            let mut buf = [0u8; 1];
+            prot_stream.read_exact(&mut buf)?;
             buf[0] != 0x00
         } else {
             false
@@ -229,6 +234,102 @@ where
 }
 
 // https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc
+/// Strips the password protection or "Never Convert" setting of a `FactoryTalk` View
+/// MER file
+///
+/// # Arguments
+///
+/// * `path` - A path to the file to be checked
+///
+/// # Examples
+///
+/// ```
+/// use ab_versions::strip_prot_mer;
+/// strip_prot_mer(&path_to_file).unwrap();
+/// ```
+///
+/// # Errors
+///
+/// Will return `Err`  if there is an error trying to access the file,
+// or the file is invalid.
+fn strip_prot_mer<P: AsRef<Path>>(path: P) -> Result<(), FtvFileError> {
+    // Note from what I recall of my earlier testing, removing the stream "/FILE_PROTECTION"
+    // or setting it to a single byte of 0, or 7 bytes of 0, also removed the protection and
+    // caused no problems that I could tell. To err on the side of caution, it seemed safer
+    //to leave the "/FILE_PROTECTION" stream in place and set it's byte to the 7 byte pattern
+    //that seems to be used for all unlocked files.
+
+    // Also of note if an MER is set to "Never Convert" stripping the protection this way will work
+    // and allows the MER to be restored. I've tested this on MERs from version 12 all the way down to
+    // MER Version 5 which doesn't give you a choice and is always "Never Convert", and it always seems
+    // to work
+
+    //Ok so I never had access to a file with version lower than 5, but my research told me that they didn't contain
+    //the info to be restored to a project file and even this method of stripping the "File Protection"
+    //wouldn't work. I finally got some v4 files (although I can't include them in the test suite)
+    //and they actually do seem to have the information to convert them, but the process is slightly different
+    //First I need to CREATE the FILE_PROTECTION stream, and set it to an unlocked value
+    //then I need to modify the VERSION_INFORMATION to look like a newer version (I'll use v5.10)
+    //no clue if this actually works on anything < v4 since I have nothing to test against
+
+    let version = get_version(&path)?;
+    let mut file = cfb::open_rw(&path)?;
+
+    if version.major_rev < 5 {
+        //if version < 5 use other method, to create FILE_PROTECTION
+        //and set the file_version to 5.10
+        //wonder if I should be checking for a .med stream to verify it's an MER here?
+        let mut fp_stream = file.create_new_stream("/FILE_PROTECTION")?;
+        fp_stream.set_len(7)?;
+        fp_stream.write_all(&[0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00])?;
+
+        let mut ver_stream = file.open_stream("/VERSION_INFORMATION")?;
+        ver_stream.write_all(&[0x03, 0x05, 0x0A])?;
+    } else {
+        //if version >= 5 use normal method just strip protection
+        let mut stream = file.open_stream("/FILE_PROTECTION")?;
+        stream.set_len(7)?;
+        stream.write_all(&[0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00])?;
+    }
+
+    drop(file);
+    fix_crc(&path)?;
+    Ok(())
+}
+
+// https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc
+/// Strips the password protection or "Never Convert" setting of an `FactoryTalk` View
+/// APA file
+///
+/// # Arguments
+///
+/// * `path` - A path to the file to be checked
+///
+/// # Examples
+///
+/// ```
+/// use ab_versions::strip_prot_apa;
+/// strip_prot_apa(&path_to_file).unwrap();
+/// ```
+///
+/// # Errors
+///
+/// Will return `Err`  if there is an error trying to access the file,
+// or the file is invalid.
+fn strip_prot_apa<P: AsRef<Path>>(path: P) -> Result<(), FtvFileError> {
+    let mut file = cfb::open_rw(&path)?;
+    let mut fp_stream = file.open_stream("/FTSPHasPwd")?;
+
+    if fp_stream.len() < 4 {
+        Err(FTypeError::ProtFileInvalid.into())
+    } else {
+        let data = [0u8; 1];
+        fp_stream.write_all(&data)?;
+        Ok(())
+    }
+}
+
+// https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc
 /// Strips the password protection or "Never Convert" setting of an `FactoryTalk` View
 /// MER or APA file
 ///
@@ -248,51 +349,11 @@ where
 /// Will return `Err`  if there is an error trying to access the file,
 // or the file is invalid.
 pub fn strip_protection<P: AsRef<Path>>(path: P) -> Result<(), FtvFileError> {
-    // Note from what I recall of my earlier testing, removing the stream "/FILE_PROTECTION"
-    // or setting it to a single byte of 0, or 7 bytes of 0, also removed the protection and
-    // caused no problems that I could tell. To err on the side of caution, it seemed safter
-    //to leave the "/FILE_PROTECTION" stream in place and set it's byte to the 7 byte pattern
-    //that seems to be used for all unlocked files.
-
-    // Also of note if an MER is set to "Never Convert" stripping the protection this way will work
-    // and allows the MER to be restored. I've tested this on MERs from version 12 all the way down to
-    // MER Version 5 which doesn't give you a choice and is always "Never Convert", and it always seems
-    // to work
-
-    //Ok so I never had access to a file with version lower than 5, but my research told me that they didn't contain
-    //the info to be restored to a project file and even this method of stripping the "File Protection"
-    //wouldn't work. I finally got some v4 files (although I can't include them in the test suite)
-    //and they actually do seem to have the information to convert them, but the process is slightly different
-    //First I need to CREATE the FILE_PROTECTION stream, and set it to an unlocked value
-    //then I need to modify the VERSION_INFORMATION to look like a newer version (I'll use v5.10)
-    //no clue if this actually works on anything < v4 since I have nothing to test against
-
-    let mut file = cfb::open_rw(&path)?;
-
-    let version = get_version(&path)?;
-
-    if version.major_rev < 5 {
-        //if version < 5 use other method, to create FILE_PROTECTION
-        //and set the file_version to 5.10
-        //wonder if I should be checking for a .med stream to verify it's an MER here?
-        let mut fp_stream = file.create_new_stream("/FILE_PROTECTION")?;
-        fp_stream.set_len(7)?;
-        fp_stream.write_all(&[0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00])?;
-
-        let mut ver_stream = file.open_stream("/VERSION_INFORMATION")?;
-        ver_stream.write_all(&[0x03, 0x05, 0x0A])?;
-    } else {
-        //if version >= 5 use normal method just stip protection
-        let mut stream = file.open_stream("/FILE_PROTECTION")?;
-        stream.set_len(7)?;
-        stream.write_all(&[0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00])?;
+    match file_type(&path) {
+        MeFiletype::Apa => strip_prot_apa(&path),
+        MeFiletype::Mer => strip_prot_mer(&path),
+        MeFiletype::Other => Err(FTypeError::InvalidVersion.into()),
     }
-
-    drop(file);
-
-    fix_crc(&path)?;
-
-    Ok(())
 }
 
 // https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc
@@ -339,7 +400,7 @@ where
 }
 
 /// Updates the CRC32 at the end of a `FactoryTalk` View
-/// MER or APA file, to ensure it restores properly after stripping the protection
+/// MER file, to ensure it restores properly after stripping the protection
 ///
 /// # Arguments
 ///
@@ -388,7 +449,6 @@ pub fn file_type<P: AsRef<Path>>(path: P) -> MeFiletype {
             };
         }
     }
-
     MeFiletype::Other
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub enum FtvFileError {
 pub enum MeFiletype {
     Apa,
     Mer,
+    Other,
 }
 
 /// Holds the version number of the file.
@@ -369,8 +370,26 @@ pub fn fix_crc<P: AsRef<Path>>(path: P) -> Result<(), FtvFileError> {
     Ok(())
 }
 
-pub fn file_type(file: &CompoundFile<File>) -> MeFiletype {
-    todo!()
+pub fn file_type<P: AsRef<Path>>(path: P) -> MeFiletype {
+    // What's the best way to determine if it's an APA or MER?
+    // I could simply look at the file extension. The Application
+    // Manager will ensure that it has the right extension since that's
+    // historically important on Windows.
+    // I'll go with the file extension for now, but it's possible
+    // if I could do something else in the future like look for the .med
+    // or look for the HMIServer folder, or read what's in the
+    // PRODUCT_VERSION_INFORMATION stream (if I can interpret it)
+    if let Some(ext) = path.as_ref().extension() {
+        if let Some(ext) = ext.to_ascii_lowercase().to_str() {
+            return match ext {
+                "apa" => MeFiletype::Apa,
+                "mer" => MeFiletype::Mer,
+                _ => MeFiletype::Other,
+            };
+        }
+    }
+
+    MeFiletype::Other
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This pull fixes the issue with restoring unlocked MERs on newer versions of Application Manager, and also fixes some issues with unlocking APA files that had never been fully resolved.